### PR TITLE
[SC-75921]: MESSENGER WIDGET: Form in Messenger Widget not showing field with dependency rules

### DIFF
--- a/packages/components/src/utils/DynamicForm.js
+++ b/packages/components/src/utils/DynamicForm.js
@@ -107,12 +107,12 @@ class DynamicForm {
     switch (op) {
       case 'is':
         if (typeName === 'choice') {
-          return targetValue.indexOf(value) !== -1;
+          return targetValue.findIndex(immVal => immVal === value || `${immVal}` === `${value}`) !== -1;
         }
         return targetValue === value;
       case 'not':
         if (typeName === 'choice') {
-          return targetValue.indexOf(value) === -1;
+          return targetValue.findIndex(immVal => immVal === value || `${immVal}` === `${value}`) === -1;
         }
         return targetValue !== value;
       case 'isset':


### PR DESCRIPTION
Fix sometimes choice fields are ints and doesn't trigger he term to show other fields