### PR TITLE
Add support for uploading multiple files

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -2,6 +2,6 @@
   "packages": [
     "packages/*"
   ],
-  "version": "1.2.17",
+  "version": "1.2.22-alpha.0",
   "npmClient": "yarn"
 }

--- a/lerna.json
+++ b/lerna.json
@@ -2,6 +2,6 @@
   "packages": [
     "packages/*"
   ],
-  "version": "1.2.22-alpha.0",
+  "version": "1.2.22",
   "npmClient": "yarn"
 }

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@deskpro/portal-components",
-  "version": "1.2.17",
+  "version": "1.2.22-alpha.0",
   "description": "Deskpro Portal Components",
   "private": false,
   "homepage": "https://deskpro.github.io/portal-components",

--- a/packages/components/src/Components/Inputs/FileUpload.tsx
+++ b/packages/components/src/Components/Inputs/FileUpload.tsx
@@ -176,7 +176,7 @@ export class FileUploadInput extends React.Component<FileUploadInputProps, FileU
     if (typeof response === 'string') {
       response = JSON.parse(response);
     }
-    const files = this.state.files.concat([response.blob]);
+    const files = this.state.files.concat(response.blobs || response.blob);
     this.setState({
       files,
       pendingFiles: [],

--- a/packages/components/src/utils/AJAXSubmit.ts
+++ b/packages/components/src/utils/AJAXSubmit.ts
@@ -65,7 +65,7 @@ const AJAXSubmit = (function () {
     const formData = new FormData();
     for (let nFile = 0; nFile < config.files.length; nFile++) {
       const oFile = config.files[nFile];
-      formData.append(`file[${config.name}]`, oFile);
+      formData.append(`file[${config.name}][]`, oFile);
     }
     formData.append('file[_dp_csrf_token]', config.token);
     submitData(config, formData);

--- a/packages/portal-style/package.json
+++ b/packages/portal-style/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@deskpro/portal-style",
-  "version": "1.2.17",
+  "version": "1.2.22-alpha.0",
   "description": "Styling for for Deskpro Portal Interface",
   "author": "DeskPRO <support@deskpro.com>",
   "license": "SEE LICENSE IN LICENSE",


### PR DESCRIPTION
Add support for uploading multiple files with fallback to previous behaviour if the BE does not return arrays of blobs in the response.