### PR TITLE
Fix duplicate file picker on Android mobile browsers [sc-205285]

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -2,6 +2,6 @@
   "packages": [
     "packages/*"
   ],
-  "version": "1.2.29",
+  "version": "1.2.30",
   "npmClient": "yarn"
 }

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@deskpro/portal-components",
-  "version": "1.2.27",
+  "version": "1.2.30",
   "description": "Deskpro Portal Components",
   "private": false,
   "homepage": "https://deskpro.github.io/portal-components",

--- a/packages/components/src/Components/Inputs/FileUpload.tsx
+++ b/packages/components/src/Components/Inputs/FileUpload.tsx
@@ -206,7 +206,7 @@ export class FileUploadInput extends React.Component<FileUploadInputProps, FileU
   };
 
   handleKeyPress = (e) => {
-    if (e.key === ' ') {
+    if (e.key === ' ' || e.key === 'Enter') {
       e.preventDefault();
       this.dropZone.open();
     }
@@ -287,11 +287,11 @@ export class FileUploadInput extends React.Component<FileUploadInputProps, FileU
               <input id={id} {...getInputProps()} />
               <label
                 className="choose"
+                role="button"
                 tabIndex={0}
                 onKeyDown={this.handleKeyPress}
                 onFocus={this.handleFocus}
                 onBlur={this.handleBlur}
-                htmlFor={id}
               >
                 <FileIcon />
                 {multiple ? this.i18n.chooseFiles : this.i18n.chooseAFile}

--- a/packages/components/src/Components/Inputs/FileUpload.tsx
+++ b/packages/components/src/Components/Inputs/FileUpload.tsx
@@ -205,13 +205,6 @@ export class FileUploadInput extends React.Component<FileUploadInputProps, FileU
     }
   };
 
-  handleKeyPress = (e) => {
-    if (e.key === ' ' || e.key === 'Enter') {
-      e.preventDefault();
-      this.dropZone.open();
-    }
-  };
-
   handleBlur = () => {
     this.setState({
       focused: false
@@ -285,17 +278,15 @@ export class FileUploadInput extends React.Component<FileUploadInputProps, FileU
               tabIndex={-1}
             >
               <input id={id} {...getInputProps()} />
-              <label
+              <button
+                type="button"
                 className="choose"
-                role="button"
-                tabIndex={0}
-                onKeyDown={this.handleKeyPress}
                 onFocus={this.handleFocus}
                 onBlur={this.handleBlur}
               >
                 <FileIcon />
                 {multiple ? this.i18n.chooseFiles : this.i18n.chooseAFile}
-              </label>
+              </button>
               <div className="or">{this.i18n.or}</div>
               <div className="dnd">
                 <DndIcon />

--- a/packages/components/src/style.css
+++ b/packages/components/src/style.css
@@ -651,6 +651,10 @@
         border-radius: 4px;
         padding: 10px;
         display: inline-block;
+        background: none;
+        font: inherit;
+        color: inherit;
+        cursor: pointer;
       }
       & .or {
         display: inline-block;

--- a/packages/components/tests/jest/Components/Inputs/testFileUpload.test.tsx
+++ b/packages/components/tests/jest/Components/Inputs/testFileUpload.test.tsx
@@ -1,0 +1,171 @@
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-nocheck
+import * as React from 'react'
+import * as ReactDOM from 'react-dom'
+import { act } from 'react-dom/test-utils'
+import { describe, expect, it } from '@jest/globals'
+import { FileUploadInput } from '../../../../src/Components/Inputs/FileUpload'
+
+// Minimal props for FileUploadInput
+const baseProps = {
+  id:        'test-upload',
+  multiple:  true,
+  url:       '/upload',
+  csrfToken: 'token',
+  label:     'Attachments',
+  onChange:  () => {},
+  i18n:      {},
+  files:     [],
+  maxSize:   Infinity,
+}
+
+// Helper: render into a real DOM container so browser-level events work
+function renderIntoDocument(element: React.ReactElement) {
+  const container = document.createElement('div')
+  document.body.appendChild(container)
+  act(() => {
+    ReactDOM.render(element, container)
+  })
+  return {
+    container,
+    unmount() {
+      act(() => {
+        ReactDOM.unmountComponentAtNode(container)
+      })
+      document.body.removeChild(container)
+    },
+  }
+}
+
+// Count actual click events dispatched on a DOM node
+function countInputClicks(container: HTMLElement): { count: number; cleanup: () => void } {
+  const input = container.querySelector<HTMLInputElement>('input[type="file"]')
+  if (!input) throw new Error('No file input found')
+  let count = 0
+  const handler = (e: Event) => {
+    // Prevent browser from trying to open a real file dialog in test env
+    e.preventDefault()
+    count++
+  }
+  input.addEventListener('click', handler)
+  return {
+    get count() { return count },
+    cleanup() {
+      input.removeEventListener('click', handler)
+    },
+  }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Sanity: rendering
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('FileUploadInput — rendering', () => {
+  it('renders a file input element', () => {
+    const { container, unmount } = renderIntoDocument(<FileUploadInput {...baseProps} />)
+    const input = container.querySelector('input[type="file"]')
+    expect(input).not.toBeNull()
+    unmount()
+  })
+
+  it('shows "Choose files" text when multiple=true', () => {
+    const { container, unmount } = renderIntoDocument(<FileUploadInput {...baseProps} multiple={true} />)
+    const label = container.querySelector('label.choose')
+    expect(label).not.toBeNull()
+    expect(label!.textContent).toContain('Choose files')
+    unmount()
+  })
+
+  it('shows "Choose a file" text when multiple=false', () => {
+    const { container, unmount } = renderIntoDocument(<FileUploadInput {...baseProps} multiple={false} />)
+    const label = container.querySelector('label.choose')
+    expect(label).not.toBeNull()
+    expect(label!.textContent).toContain('Choose a file')
+    unmount()
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Bug: double file-dialog on mobile — clicking .choose label must open the
+// file dialog exactly ONCE.
+//
+// Root cause: inner label has htmlFor={id}, sitting inside the react-dropzone
+// root div that spreads getRootProps(). One tap fires:
+//   1. native label→input activation  → input.click() #1
+//   2. click bubbles to dropzone root onClick → openFileDialog() → input.click() #2
+//
+// With the bug present this test counts 2 input click events and FAILS.
+// After the fix (htmlFor removed from .choose label) it counts 1 and PASSES.
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('FileUploadInput — double-open bug (sc-205285)', () => {
+  it('clicking the choose label opens the file dialog exactly once', () => {
+    const { container, unmount } = renderIntoDocument(<FileUploadInput {...baseProps} />)
+
+    const tracker = countInputClicks(container)
+    const chooseLabel = container.querySelector<HTMLElement>('label.choose')
+    expect(chooseLabel).not.toBeNull()
+
+    act(() => {
+      chooseLabel!.click()
+    })
+
+    tracker.cleanup()
+    unmount()
+
+    // With the bug: htmlFor on the label causes native label→input activation (1)
+    // AND the click bubbles to the dropzone root which calls openFileDialog()→input.click() (2).
+    // After the fix: no htmlFor, only the dropzone onClick fires (1).
+    expect(tracker.count).toBe(1)
+  })
+
+  it('pressing Space on the choose label opens the file dialog exactly once', () => {
+    const { container, unmount } = renderIntoDocument(<FileUploadInput {...baseProps} />)
+
+    const tracker = countInputClicks(container)
+    const chooseLabel = container.querySelector('label.choose')
+    expect(chooseLabel).not.toBeNull()
+
+    act(() => {
+      // KeyboardEvent is on window in the manual JSDOM setup
+      const event = new window.KeyboardEvent('keydown', {
+        key:      ' ',
+        bubbles:  true,
+        cancelable: true,
+      })
+      chooseLabel.dispatchEvent(event)
+    })
+
+    tracker.cleanup()
+    unmount()
+
+    // handleKeyPress calls this.dropZone.open() which calls input.click() once.
+    expect(tracker.count).toBe(1)
+  })
+
+  it('pressing Enter on the choose label opens the file dialog exactly once', () => {
+    const { container, unmount } = renderIntoDocument(<FileUploadInput {...baseProps} />)
+
+    const tracker = countInputClicks(container)
+    const chooseLabel = container.querySelector('label.choose')
+    expect(chooseLabel).not.toBeNull()
+
+    act(() => {
+      // KeyboardEvent is on window in the manual JSDOM setup
+      const event = new window.KeyboardEvent('keydown', {
+        key:      'Enter',
+        bubbles:  true,
+        cancelable: true,
+      })
+      chooseLabel.dispatchEvent(event)
+    })
+
+    tracker.cleanup()
+    unmount()
+
+    // The label now has role="button"; Enter must open the dialog to match button parity.
+    // handleKeyPress calls this.dropZone.open() which calls input.click() once.
+    expect(tracker.count).toBe(1)
+  })
+
+})

--- a/packages/components/tests/jest/Components/Inputs/testFileUpload.test.tsx
+++ b/packages/components/tests/jest/Components/Inputs/testFileUpload.test.tsx
@@ -70,7 +70,7 @@ describe('FileUploadInput — rendering', () => {
 
   it('shows "Choose files" text when multiple=true', () => {
     const { container, unmount } = renderIntoDocument(<FileUploadInput {...baseProps} multiple={true} />)
-    const label = container.querySelector('label.choose')
+    const label = container.querySelector('button.choose')
     expect(label).not.toBeNull()
     expect(label!.textContent).toContain('Choose files')
     unmount()
@@ -78,7 +78,7 @@ describe('FileUploadInput — rendering', () => {
 
   it('shows "Choose a file" text when multiple=false', () => {
     const { container, unmount } = renderIntoDocument(<FileUploadInput {...baseProps} multiple={false} />)
-    const label = container.querySelector('label.choose')
+    const label = container.querySelector('button.choose')
     expect(label).not.toBeNull()
     expect(label!.textContent).toContain('Choose a file')
     unmount()
@@ -99,73 +99,40 @@ describe('FileUploadInput — rendering', () => {
 // ─────────────────────────────────────────────────────────────────────────────
 
 describe('FileUploadInput — double-open bug (sc-205285)', () => {
-  it('clicking the choose label opens the file dialog exactly once', () => {
+  it('clicking the choose button opens the file dialog exactly once', () => {
     const { container, unmount } = renderIntoDocument(<FileUploadInput {...baseProps} />)
 
     const tracker = countInputClicks(container)
-    const chooseLabel = container.querySelector<HTMLElement>('label.choose')
-    expect(chooseLabel).not.toBeNull()
+    const chooseButton = container.querySelector<HTMLElement>('button.choose')
+    expect(chooseButton).not.toBeNull()
 
     act(() => {
-      chooseLabel!.click()
+      chooseButton!.click()
     })
 
     tracker.cleanup()
     unmount()
 
-    // With the bug: htmlFor on the label causes native label→input activation (1)
+    // With the bug: htmlFor on the old label caused native label→input activation (1)
     // AND the click bubbles to the dropzone root which calls openFileDialog()→input.click() (2).
-    // After the fix: no htmlFor, only the dropzone onClick fires (1).
+    // After the fix: a real button with no input association — only the dropzone onClick fires (1).
     expect(tracker.count).toBe(1)
   })
 
-  it('pressing Space on the choose label opens the file dialog exactly once', () => {
+  it('renders choose as a native button so keyboard activation works (WCAG)', () => {
     const { container, unmount } = renderIntoDocument(<FileUploadInput {...baseProps} />)
 
-    const tracker = countInputClicks(container)
-    const chooseLabel = container.querySelector('label.choose')
-    expect(chooseLabel).not.toBeNull()
+    // A native <button type="button"> gets Enter/Space activation and focusability
+    // from the browser (jsdom does not synthesize click from keydown, so we assert
+    // the semantics rather than simulate the keyboard behaviour).
+    const chooseButton = container.querySelector('button.choose')
+    expect(chooseButton).not.toBeNull()
+    expect(chooseButton!.getAttribute('type')).toBe('button')
 
-    act(() => {
-      // KeyboardEvent is on window in the manual JSDOM setup
-      const event = new window.KeyboardEvent('keydown', {
-        key:      ' ',
-        bubbles:  true,
-        cancelable: true,
-      })
-      chooseLabel.dispatchEvent(event)
-    })
+    // It must NOT be a label tied to the input — that is what double-opened the picker.
+    expect(container.querySelector('label.choose')).toBeNull()
 
-    tracker.cleanup()
     unmount()
-
-    // handleKeyPress calls this.dropZone.open() which calls input.click() once.
-    expect(tracker.count).toBe(1)
-  })
-
-  it('pressing Enter on the choose label opens the file dialog exactly once', () => {
-    const { container, unmount } = renderIntoDocument(<FileUploadInput {...baseProps} />)
-
-    const tracker = countInputClicks(container)
-    const chooseLabel = container.querySelector('label.choose')
-    expect(chooseLabel).not.toBeNull()
-
-    act(() => {
-      // KeyboardEvent is on window in the manual JSDOM setup
-      const event = new window.KeyboardEvent('keydown', {
-        key:      'Enter',
-        bubbles:  true,
-        cancelable: true,
-      })
-      chooseLabel.dispatchEvent(event)
-    })
-
-    tracker.cleanup()
-    unmount()
-
-    // The label now has role="button"; Enter must open the dialog to match button parity.
-    // handleKeyPress calls this.dropZone.open() which calls input.click() once.
-    expect(tracker.count).toBe(1)
   })
 
 })


### PR DESCRIPTION
One tap on "Choose files" opened two native file pickers on Android (Chrome/Edge/Samsung Internet), repeatedly prompting users to re-select and creating duplicate attachments.

The inner choose label had `htmlFor` pointing at the file input while sitting inside the react-dropzone root (`getRootProps`), so a single tap triggered both native label activation and the dropzone onClick. Desktop Chrome silently swallows the second chooser request, which is why this only manifested on Android.

- Replace the choose `<label htmlFor>` with a native `<button type="button">` — the dropzone root onClick is the single open path, and the button gets focus/Enter/Space activation from the browser (WCAG)
- Reset button UA styles on `.choose` so visuals are unchanged
- Add regression tests (fail with 2 dialog opens pre-fix, pass with 1 post-fix)
- Bump version to 1.2.30