### PR TITLE
Center custom uploaded category & community icons in help center [SR-535]

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -2,6 +2,6 @@
   "packages": [
     "packages/*"
   ],
-  "version": "1.2.30",
+  "version": "1.2.31",
   "npmClient": "yarn"
 }

--- a/packages/portal-style/package.json
+++ b/packages/portal-style/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@deskpro/portal-style",
-  "version": "1.2.29",
+  "version": "1.2.31",
   "description": "Styling for for Deskpro Portal Interface",
   "author": "DeskPRO <support@deskpro.com>",
   "license": "SEE LICENSE IN LICENSE",

--- a/packages/portal-style/src/modules/_kb-category-title.scss
+++ b/packages/portal-style/src/modules/_kb-category-title.scss
@@ -14,6 +14,7 @@
       img {
         max-width: 26px;
         max-height: 26px;
+        vertical-align: top;
       }
     }
   }

--- a/packages/portal-style/src/pages/_community-home.scss
+++ b/packages/portal-style/src/pages/_community-home.scss
@@ -94,6 +94,7 @@
       img {
         max-width: 48px;
         max-height: 48px;
+        vertical-align: top;
       }
     }
 


### PR DESCRIPTION
## What

Custom uploaded (blob) category and community icons render misaligned inside their circular background in the help center — pushed ~6px below centre — while emoji and Font Awesome icons centre correctly.

## Why

Custom icons render as an inline \`<img>\` inside the flex-centred circular icon container. Inline images sit on the line-box baseline, leaving descender leading below them, so the visible image is pushed down. Guides icons already compensate with a \`vertical-align\` nudge; the KB category (\`.dp-po-category-title-icon .dp-po-icon img\`) and community (\`.dp-po-community-row-icon .dp-po-icon img\`) containers were missing it.

## Change

Add \`vertical-align: top\` to both icon \`img\` rules, mirroring the existing guides pattern.

- \`packages/portal-style/src/modules/_kb-category-title.scss\`
- \`packages/portal-style/src/pages/_community-home.scss\`

## Verification

- Rebuilt \`dist/style.css\`; confirmed both selectors emit \`vertical-align:top\`, guides rule unchanged.
- Served the built CSS on a local help center and re-measured: custom icon offset from circle centre **0px** (was +5.91px) — centred, matching emoji/FA icons.

## Risk

Low — additive CSS on two specific selectors (KB category + community icons). Guides and all other portal images untouched.

Linear: https://linear.app/deskpro/issue/SR-535/hc-custom-category-icon-positioning